### PR TITLE
Use loader-utils getOptions instead of parseQuery

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,11 +17,11 @@ module.exports = function(content) {
     if(!this.emitFile)
         throw new Error("emitFile is required from module system");
 
-    var query = loaderUtils.parseQuery(this.query);
-    var url = loaderUtils.interpolateName(this, query.name || "[hash].[ext]", {
-        context: query.context || this.options.context,
+    var options = loaderUtils.getOptions(this);
+    var url = loaderUtils.interpolateName(this, options.name || "[hash].[ext]", {
+        context: options.context || this.options.context,
         content: content,
-        regExp: query.regExp
+        regExp: options.regExp
     });
     this.emitFile(url, content);
     return content

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "move-file-loader",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "license": "MIT",
     "description": "A Webpack loader to move files from one location to another and return the contents.",
     "main": "index.js",


### PR DESCRIPTION
`parseQuery` is deprecated in the latest version of `loader-utils` and
puts a warning in the console when webpack is compiling. This updates
the package to use `getOptions` instead of `parseQuery`.